### PR TITLE
Fix 'utf8_decode' is deprecated

### DIFF
--- a/TextformatterWrapTable.module.php
+++ b/TextformatterWrapTable.module.php
@@ -97,7 +97,7 @@ class TextformatterWrapTable extends Textformatter implements Module, Configurab
             $html = $dom->saveHTML($dom->documentElement);
             if (strpos($html, "<html><body>") === 0) $html = substr($html, 12);
             if ($this->endsWidth($html, "</body></html>")) $html = substr($html, 0, -14);
-            $string = trim(utf8_decode($html));
+            $string = trim(mb_convert_encoding($html, "UTF-8"));
         }
     }
 


### PR DESCRIPTION
Hello pmichaelis

The Method 'utf8_decode' is going to be removed as of version 9.0.

In case prior versions of PHP 4.0.6 and lower don't need to be supported anymore we can simply replace the function.

https://www.php.net/manual/en/function.mb-convert-encoding.php

I didn't test ist thoroughl, but it fixed the warning I got in my project.