### PR TITLE
Fix loadHTML does not load special chars correctly (uses encoding ISO-8859-1 instead of UTF-8)

### DIFF
--- a/TextformatterWrapTable.module.php
+++ b/TextformatterWrapTable.module.php
@@ -67,8 +67,9 @@ class TextformatterWrapTable extends Textformatter implements Module, Configurab
 
         if ($string) {
             $dom = new \DOMDocument('1.0', 'utf-8');
-            // fix bug, see https://stackoverflow.com/a/22490902/6370411
-            $dom->loadHTML($string);
+            // fix bug 1, see https://stackoverflow.com/a/22490902/6370411
+            // fix bug 2, see https://stackoverflow.com/a/8218649
+            $dom->loadHTML(mb_encode_numericentity($string, [0x80, 0x10FFFF, 0, ~0], 'UTF-8'), LIBXML_NOERROR);
             $selector = new \DOMXPath($dom);
             $length = $dom->getElementsByTagName('table')->length;
 


### PR DESCRIPTION
Hello pmichaelis

Special characters like ä ü and ü were incorrectly encoded in my project. This solution fixes it, however I don't fully understand the convmap values ([0x80, 0x10FFFF, 0, ~0]).

See: https://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly/8218649#8218649